### PR TITLE
Forbedre "Innsyn i dokumenter"

### DIFF
--- a/innhold.tex
+++ b/innhold.tex
@@ -105,9 +105,7 @@ Tillitsvalgt har taushetsplikt, og vil ved behov videreformidle saker anonymiser
 Styret plikter å formidle tilbudet om tillitsvalgt til medlemmer av Hackerspace, behandle saker som blir tatt opp av tillitsvalgt, og respektere taushetsplikten til tillitsvalgt.
 
 \subsection{Innsyn i dokumenter}\label{sec:struktur:innsyn}
-
 Alle dokumenter i gruppene og styret skal, så sant de er av interesse for resten av Hackerspace og ikke er taushetsbelagte, være åpent tilgjengelig for innsyn for alle aktive medlemmer og panger som definert i paragraf~\ref{sec:medlemskap:medlemstyper}.
-
 
 
 \section{Generalforsamling}\label{sec:generalforsamling}

--- a/innhold.tex
+++ b/innhold.tex
@@ -105,7 +105,8 @@ Tillitsvalgt har taushetsplikt, og vil ved behov videreformidle saker anonymiser
 Styret plikter å formidle tilbudet om tillitsvalgt til medlemmer av Hackerspace, behandle saker som blir tatt opp av tillitsvalgt, og respektere taushetsplikten til tillitsvalgt.
 
 \subsection{Innsyn i dokumenter}\label{sec:struktur:innsyn}
-Alle dokumenter i gruppene og styret skal, så sant de er av interesse for resten av Hackerspace og ikke er taushetsbelagte, være åpent tilgjengelig for innsyn for alle aktive medlemmer og panger som definert i paragraf~\ref{sec:medlemskap:medlemstyper}.
+Alle dokumenter som styret behandler eller er i besittelse av, som er av interesse for aktive medlemmer eller panger (definert i paragraf~\ref{sec:medlemskap:medlemstyper}), og som ikke inneholder taushetsbelagt informasjon, skal være åpent tilgjengelig for innsyn for alle aktive medlemmer og panger.
+Styret skal også sørge for at planleggingsdokumenter og ferdigprodusert materiale tilhørende hver enkelt gruppe, får samme behandling.
 
 
 \section{Generalforsamling}\label{sec:generalforsamling}


### PR DESCRIPTION
*Fra commit-meldingen til c34ced979e5a7f6f850531aeb802da82ddfdd5c3:*
Denne endringen gjør at bare styret er nødt til å være åpne om alt de gjør (som var den opprinnelige intensjonen til paragrafen), fordi de er til for medlemsbasens beste, og medlemmer skal dermed ha rett til å få innsyn i hvordan styret leder Hackerspace, for å kunne bedømme hvor godt styret gjør jobben sin.

Endringen gjør også at gruppene for øvrig, bare trenger å være åpne om planlegging og ferdiglagde ting (som kodefiler, 3D-modeller, kunst/art, programvare-builds, o.l.), som er det som er definert som å være "av interesse for aktive medlemmer eller panger". Dette er fordi det er den informasjonen som trengs for at styret skal kunne bedømme hvor godt gruppene selv blir ledet, og for at resten av Hackerspace skal kunne få glede av det som blir lagd. Alt annet gruppene gjør, kan de selv velge om de vil være åpne om.