### PR TITLE
Begrensning av fullmakt

### DIFF
--- a/innhold.tex
+++ b/innhold.tex
@@ -127,7 +127,7 @@ Det er ikke tillatt å stemme blankt på en statuttendring; det er dog tillatt �
 
 Alle medlemmer -- både aktive og panger -- har møte- og talerett.
 Aktive medlemmer har stemmerett.
-Stemmeretten kan gis videre ved skriftlig fullmakt; denne kontrolleres av tellekorpset på generalforsamlingen.
+Stemmeretten kan gis videre ved skriftlig fullmakt til et annet medlem, men et medlem kan kun disponere en fullmakt og sin egen stemme; denne kontrolleres av tellekorpset på generalforsamlingen.
 
 \subsection{Etter generalforsamling}\label{sec:generalforsamling:etter}
 Den nye ledelsen trer i kraft to uker etter generalforsamlingen.


### PR DESCRIPTION
Vi ønsker å begrense mengden fullmakter et medlem kan disponerer, slik at et medlem ikke ender opp med 4 fullmakter og kan bestemme valget under en genforsamling.