### PR TITLE
opdaterte statuett endringer fra 2024

### DIFF
--- a/innhold.tex
+++ b/innhold.tex
@@ -16,13 +16,14 @@ Et aktivt medlem er en student ved NTNU som har takket ja til medlemskap etter o
 Et aktivt medlem skal så langt det er mulig følge medlemspliktene (\ref{sec:medlemskap:medlemsplikter}).
 
 Et pensjonert medlem -- en pang -- er et tidligere aktivt medlem som ikke har blitt kastet ut (\ref{sec:medlemskap:utkastelse}), som var aktivt medlem i minst 4 semestre eller styremedlem i 2 semestre (medregnet det man ble tatt opp i), og som har gjennomført Hackerspace Grunnkurs (\ref{sec:medlemskap:medlemsplikter}).
-En pang har -- så lenge de er studenter ved NTNU -- fri tilgang til prosjektets lokaler, utstyr og kommunikasjonskanaler på linje med aktive medlemmer.
+En pang - så lenge de har korttilgang til NTNUs lokaler - fri tilgang til prosjektets lokaler, utstyr og kommunikasjonskanaler på linje med aktive medlemmer
 Etter endt studium har pangen ikke lenger samme tilgang til lokalene, ettersom at de ikke lenger har generell adgang til NTNUs lokaler som krever nøkkelkort. Tilgang til lokalet bør være eneste forskjell på en pang som fremdeles studerer, og en pang som ikke lenger studerer.
 
 \subsection{Opptak}\label{sec:medlemskap:opptak}
 Styret har ansvar for å arrangere opptak; alle studenter ved NTNU kan søke.
 
-Opptak skal som hovedregel avholdes hver høst. Ekstra opptak kan avholdes på våren om det er ønskelig.
+Det er løpende opptak, dette innebærer at studenter kan legge inn
+søknad for medlemskap i Hackerspace når som helst.
 
 Alle personopplysninger knyttet til søknadsprosessen er taushetsbelagte. Alle skriftlige dokumenter med personopplysninger skal destrueres innen én måned etter opptaksperioden.
 
@@ -80,6 +81,12 @@ Ved avstemninger i styret tildeles én stemme til hver av de statuttfestede grup
 Om det eksisterer tre eller færre prosjektgrupper, så tildeles disse gruppene én stemme hver. Om det eksisterer flere enn 3 prosjektgrupper så tildeles disse $\frac{3}{(\text{antall prosjektgrupper})}$ stemmer, slik at prosjektgruppene til sammen har tre stemmer. En prosjektgruppe kan ikke har mer enn én stemme.
 Om nødvendig, tildeles én vippestemme til økonomiansvarlig.
 
+Dersom en av de permanente gruppene (Devops og LabOps) ikke har
+noen medlemmer, vil oppgavene falle på Ledelsen, fram til gruppen får
+medlemmer igjen. En representant for gruppa vil bli oppnevnt av styret og
+vil disponere stemmen til gruppa fram til gruppen får medlemmer igjen.
+
+
 \subsection{Ledelsen}\label{sec:struktur:ledelsen}
 Ledelsen består av leder, nestleder og økonomiansvarlig.
 Disse stillingene velges ved personvalg (\ref{sec:valg}) av generalforsamlingen (\ref{sec:generalforsamling}).
@@ -127,7 +134,8 @@ Det er ikke tillatt å stemme blankt på en statuttendring; det er dog tillatt �
 
 Alle medlemmer -- både aktive og panger -- har møte- og talerett.
 Aktive medlemmer har stemmerett.
-Stemmeretten kan gis videre ved skriftlig fullmakt; denne kontrolleres av tellekorpset på generalforsamlingen.
+Stemmeretten kan gis videre ved skriftlig fullmakt til et annet medlem; dette kontrolleres av tellekorpset på generalforsamlingen.
+Hvert enkelt medlem kan disponere opptil to fullmakter i tillegg til sin egen stemme.
 
 \subsection{Etter generalforsamling}\label{sec:generalforsamling:etter}
 Den nye ledelsen trer i kraft to uker etter generalforsamlingen.


### PR DESCRIPTION
Opdaterte statuett endringer fra 2024.

Hvis en fastgruppe mangler medlemmer er det ledelsens ansvar å ta over for oppgavene.

Endret fra fastopptak på høsten, til å ha et kontinuerlig løpende opptak.

Begrenset antall fullmakter man kan motta på genfors til 2

En pang - så lenge de har korttilgang til NTNUs lokaler - fri tilgang til prosjektets lokaler(ny statuett.)